### PR TITLE
Fixes the density chart out of selection zones color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 [x] Benchmark with a lot of nodes
     - Initial render is relativelly fast with 100k data points
     - Tooltip highlight works smoothly with 300k data points
-    - Brushing works with 100k data points, and smoothly with 25k data points
+    - Brushing works with 70k data points, and smoothly with 25k data points
 [x] Handle different widths and heights correctly
 [x] Remove global selectors
 [ ] Create a static page with the story book

--- a/src/DensityChart/DensityChart.js
+++ b/src/DensityChart/DensityChart.js
@@ -7,6 +7,9 @@ import {
     drawRect,
     getRenderContext
 } from "../canvasRenderUtils";
+import {
+    havePropsChanged
+} from "../utils";
 import { brushX } from "d3-brush";
 
 /**
@@ -78,9 +81,7 @@ export default class DensityChart extends PureComponent {
 
         // We only need to re-render the density chart if the data, the weight, the height or
         // the chart x scale have changed.
-        if (prevProps.data !== this.props.data || prevProps.width !== this.props.width ||
-                prevProps.height !== this.props.height ||
-                prevProps.densityChartXScale !== this.props.densityChartXScale) {
+        if (this._shouldRedrawDensityChart(prevProps)) {
             this._drawDensityChart();
         }
     }
@@ -146,6 +147,23 @@ export default class DensityChart extends PureComponent {
         d3Select(this.densityBrushRef.current)
             .call(this.brush.move, domain);
     };
+
+    /**
+     * Returns whenever it is necessary to re-render the density chart, based on the current and previous
+     * props.
+     * @param {Object} prevProps
+     * @returns {boolean}
+     */
+    _shouldRedrawDensityChart(prevProps) {
+        return havePropsChanged(this.props, prevProps, [
+            "brushDomainMin",
+            "brushDomainMax",
+            "data",
+            "width",
+            "height",
+            "densityChartXScale"
+        ]);
+    }
 
     /**
      * Draws density strip plot in canvas.

--- a/src/utils.js
+++ b/src/utils.js
@@ -118,6 +118,27 @@ export function dateToTimestamp(date) {
 }
 
 /**
+ * Compares the props with the given names in the two prop objects and
+ * returns whenever they have the same value (shallow comparison).
+ *
+ * @param {Object} props
+ * @param {Object} prevProps
+ * @param {Array.<string>} propNames
+ * @returns {boolean}
+ */
+export function havePropsChanged(props, prevProps, propNames) {
+    for (let i = 0; i < propNames.length; i++) {
+        const propName = propNames[i];
+
+        if (prevProps.hasOwnProperty(propName) && props[propName] !== prevProps[propName]) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
  * Receives the size the component should have, the padding and the how much vertical space the
  * histogram and the density plots should take and calculates the charts sizes and positions
  *

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -5,7 +5,8 @@ import {
     isHistogramDataEqual,
     dateToTimestamp,
     calculateChartsPositionsAndSizing,
-    calculateChartSizesAndDomain
+    calculateChartSizesAndDomain,
+    havePropsChanged
 } from "./utils";
 import { max as d3Max, min as d3Min } from "d3-array";
 import { smallSample } from "../stories/sampleData";
@@ -130,6 +131,21 @@ describe("dateToTimestamp", () => {
 
     it("returns the number if a number is passed", () => {
         expect(dateToTimestamp(1533164400000)).toBe(1533164400000);
+    });
+});
+
+describe("havePropsChanged", () => {
+    it("returns true if a prop has changed", () => {
+        expect(havePropsChanged({ name: "bob", age: 12 }, { name: "gary" }, ["name", "age"])).toBe(true);
+    });
+
+    it("returns false if no prop has changed", () => {
+        expect(havePropsChanged({ name: "bob", age: 12 }, { name: "bob" }, ["name", "age"])).toBe(false);
+    });
+
+    it("returns false if no listed prop has changed", () => {
+        expect(havePropsChanged({ name: "gary", age: 12 }, { name: "bob" }, ["age"])).toBe(false);
+        expect(havePropsChanged({ name: "gary", age: 12 }, { name: "bob", age: 12 }, ["age"])).toBe(false);
     });
 });
 


### PR DESCRIPTION
A regression was introduced because the density chart canvas was not being re-rendered.