### PR TITLE
Move `react` from `dependency` to `peerDependency`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Brushable Histogram
 
+## Unreleased
+- Move `react` in `package.json` from `dependency` to `peerDependency`.
+
 ## 1.2.1 (2019/04/9)
 - Allow the user to define a custom `brushDomain` via `props`.
 - Update Storybook to 5.x

--- a/package.json
+++ b/package.json
@@ -7,18 +7,6 @@
     "type" : "git",
     "url" : "https://github.com/feedzai/brushable-histogram.git"
   },
-  "dependencies": {
-    "d3-array": "1.2.1",
-    "d3-axis": "1.0.8",
-    "d3-brush": "1.0.4",
-    "d3-scale": "2.0.0",
-    "d3-selection": "1.3.0",
-    "d3-time": "1.0.8",
-    "d3-time-format": "2.1.1",
-    "d3-zoom": "1.7.1",
-    "react": "16.6.1",
-    "react-sizeme": "2.5.2"
-  },
   "scripts": {
     "test": "jest --coverage",
     "test:watch": "jest --watch",
@@ -38,6 +26,17 @@
     "luis.cardoso@feedzai.com",
     "marlom.girardi@feedzai.com"
   ],
+  "dependencies": {
+    "d3-array": "1.2.1",
+    "d3-axis": "1.0.8",
+    "d3-brush": "1.0.4",
+    "d3-scale": "2.0.0",
+    "d3-selection": "1.3.0",
+    "d3-time": "1.0.8",
+    "d3-time-format": "2.1.1",
+    "d3-zoom": "1.7.1",
+    "react-sizeme": "2.5.2"
+  },
   "devDependencies": {
     "@babel/cli": "^7.1.5",
     "@babel/core": "^7.1.6",
@@ -63,8 +62,12 @@
     "husky": "^1.3.1",
     "jest": "^24.7.1",
     "node-sass": "^4.10.0",
+    "react": "16.6.1",
     "react-dom": "16.6.1",
     "sass-loader": "^7.1.0"
+  },
+  "peerDependencies": {
+    "react": "16.x"
   },
   "licence": "APACHE-2.0"
 }


### PR DESCRIPTION
Put react as peer dependency to avoid version conflict between packages (#43)